### PR TITLE
Fix #2: Compile error on Windows due to conflicting trait implementations for `c_long`/`c_int` and `c_ulong`/`c_uint`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "displaydoc"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -17,6 +23,7 @@ dependencies = [
 name = "hs-bindgen-types"
 version = "0.8.0"
 dependencies = [
+ "cfg-if",
  "displaydoc",
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ version = "0.8.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+cfg-if = "1.0.0"
 displaydoc = "0.2"
 proc-macro2 = "1.0"
 quote = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ use displaydoc::Display;
 use proc_macro2::TokenStream;
 use quote::quote;
 use thiserror::Error;
+use cfg_if::cfg_if;
 
 /// Enumeration of all Haskell C-FFI safe types as the string representation of
 /// their token in Haskell.
@@ -192,13 +193,25 @@ repr_hs! {
     c_double => CDouble,
     c_float  => CFloat,
     c_int    => CInt,
-    c_long   => CLong,
     c_short  => CShort,
     c_uchar  => CUChar,
     c_uint   => CUInt,
-    c_ulong  => CULong,
     c_ushort => CUShort,
     ()       => Empty,
+}
+
+cfg_if! {
+    if #[cfg(all(target_pointer_width = "64", not(windows)))] {
+        repr_hs! {
+            c_long  => CLong,
+            c_ulong => CULong,
+        }
+    } else {
+        repr_hs! {
+            c_longlong  => CLLong,
+            c_ulonglong => CULLong,
+        }
+    }
 }
 
 impl<T> ReprHs for *const T


### PR DESCRIPTION
I choose to follow the way of the Rust core library: https://doc.rust-lang.org/src/core/ffi/mod.rs.html#175-190

But, I'm unsure about if `i64`/`u64` on Windows that should just be `c_longlong`/`c_ulonglong`: https://doc.rust-lang.org/src/core/ffi/mod.rs.html#77-78

Then how they conflict with Haskell `CLLong`/`CULLong` https://hackage.haskell.org/package/base/docs/Foreign-C-Types.html?

@adrien-zinger, thank you for helping me find this solution :)